### PR TITLE
fix: update quinn-proto and rustls-webpki for security audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Update `quinn-proto` 0.11.13 → 0.11.14 (RUSTSEC-2026-0037, DoS in Quinn endpoints)
- Update `rustls-webpki` 0.103.9 → 0.103.10 (RUSTSEC-2026-0049, CRL matching logic)

Fixes CI security audit failure on master.

## Test plan
- [ ] `cargo audit` passes with no vulnerabilities
- [ ] CI security audit job goes green