### PR TITLE
feat: 为第三方提示词增强注入 search_context 上下文

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -97,6 +97,7 @@ ace-tool-rs --base-url <API_URL> --token <AUTH_TOKEN>
 | `PROMPT_ENHANCER_BASE_URL` | 第三方 API 的基础 URL（`claude`/`openai`/`gemini`/`codex` 必需） |
 | `PROMPT_ENHANCER_TOKEN` | 第三方 API 的密钥（`claude`/`openai`/`gemini`/`codex` 必需） |
 | `PROMPT_ENHANCER_MODEL` | 第三方 API 的模型名称覆盖（可选） |
+| `PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT` | 设为 `1`、`true`、`yes` 或 `on` 时，在第三方提示词增强前先执行一次 `search_context`，将检索结果注入增强输入 |
 
 ### 示例
 
@@ -288,6 +289,14 @@ export PROMPT_ENHANCER_ENDPOINT=claude
 export PROMPT_ENHANCER_BASE_URL=https://api.anthropic.com
 export PROMPT_ENHANCER_TOKEN=your-anthropic-api-key
 ace-tool-rs --enhance-prompt "添加用户认证功能"
+
+# 如果还想在第三方增强前注入 search_context，
+# 需要同时提供 ACE 检索用的 --base-url 和 --token
+export PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT=1
+ace-tool-rs \
+  --base-url https://api.example.com \
+  --token your-ace-token \
+  --enhance-prompt "添加用户认证功能"
 ```
 
 **使用 Codex API 的示例：**
@@ -300,6 +309,14 @@ export PROMPT_ENHANCER_TOKEN=your-openai-api-key
 # 可选: export PROMPT_ENHANCER_MODEL=codex-mini
 ace-tool-rs --enhance-prompt "重构认证逻辑"
 ```
+
+**第三方增强结合 `search_context` 的说明：**
+
+- 仅对 `claude` / `openai` / `gemini` / `codex` 生效
+- 需要设置 `PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT=1`
+- 在 MCP 服务模式下，本来就需要 `--base-url` 和 `--token`
+- 在 `--enhance-prompt` 单次模式下，如果启用了这个开关，也必须额外提供 `--base-url` 和 `--token`
+- 若显式启用但检索失败，工具会返回真实错误，不会静默退回普通增强
 
 ## 支持的文件类型
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ ace-tool-rs --base-url <API_URL> --token <AUTH_TOKEN>
 | `PROMPT_ENHANCER_BASE_URL` | Base URL for third-party API (required for `claude`/`openai`/`gemini`/`codex`) |
 | `PROMPT_ENHANCER_TOKEN` | API key for third-party API (required for `claude`/`openai`/`gemini`/`codex`) |
 | `PROMPT_ENHANCER_MODEL` | Model name override for third-party API (optional) |
+| `PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT` | When set to `1`, `true`, `yes`, or `on`, runs `search_context` before third-party prompt enhancement and injects the retrieval result into the enhancement input |
 
 ### Example
 
@@ -288,6 +289,14 @@ export PROMPT_ENHANCER_ENDPOINT=claude
 export PROMPT_ENHANCER_BASE_URL=https://api.anthropic.com
 export PROMPT_ENHANCER_TOKEN=your-anthropic-api-key
 ace-tool-rs --enhance-prompt "Add user authentication"
+
+# If you also want to inject search_context before third-party enhancement,
+# you must additionally provide ACE search credentials via --base-url/--token
+export PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT=1
+ace-tool-rs \
+  --base-url https://api.example.com \
+  --token your-ace-token \
+  --enhance-prompt "Add user authentication"
 ```
 
 **Example using Codex API:**
@@ -300,6 +309,14 @@ export PROMPT_ENHANCER_TOKEN=your-openai-api-key
 # Optional: export PROMPT_ENHANCER_MODEL=codex-mini
 ace-tool-rs --enhance-prompt "Refactor authentication logic"
 ```
+
+**Using `search_context` with third-party enhancement:**
+
+- Applies only to `claude` / `openai` / `gemini` / `codex`
+- Requires `PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT=1`
+- In MCP server mode, `--base-url` and `--token` are already required
+- In one-shot `--enhance-prompt` mode, enabling this feature also requires `--base-url` and `--token`
+- When explicitly enabled, search failures are returned as real errors instead of silently falling back to plain enhancement
 
 ## Supported File Types
 

--- a/src/enhancer/prompt_enhancer.rs
+++ b/src/enhancer/prompt_enhancer.rs
@@ -20,6 +20,7 @@ use reqwest::Client;
 use tracing::{error, info, warn};
 
 use crate::config::Config;
+use crate::index::IndexManager;
 use crate::service::{
     call_claude_endpoint, call_codex_endpoint, call_gemini_endpoint, call_new_endpoint,
     call_old_endpoint, call_openai_endpoint, get_third_party_config, EnhancerEndpoint,
@@ -39,6 +40,12 @@ pub const ENV_ENHANCER_ENDPOINT: &str = "PROMPT_ENHANCER_ENDPOINT";
 /// Legacy environment variable for backward compatibility
 pub const ENV_ENHANCER_ENDPOINT_LEGACY: &str = "ACE_ENHANCER_ENDPOINT";
 
+/// Environment variable to include search_context results in third-party enhancement
+pub const ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT: &str = "PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT";
+
+const SEARCH_CONTEXT_CHAR_LIMIT: usize = 12_000;
+const NO_RELEVANT_CODE_CONTEXT: &str = "No relevant code context found for your query.";
+
 /// Get the configured enhancer endpoint type
 ///
 /// Checks `PROMPT_ENHANCER_ENDPOINT` first, then falls back to `ACE_ENHANCER_ENDPOINT`
@@ -48,6 +55,83 @@ pub fn get_enhancer_endpoint() -> EnhancerEndpoint {
         .or_else(|_| std::env::var(ENV_ENHANCER_ENDPOINT_LEGACY))
         .map(|v| EnhancerEndpoint::from_env_str(&v))
         .unwrap_or(EnhancerEndpoint::New)
+}
+
+fn should_include_search_context() -> bool {
+    matches!(
+        std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT)
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn truncate_by_chars(text: &str, max_chars: usize) -> String {
+    let char_count = text.chars().count();
+    if char_count <= max_chars {
+        return text.to_string();
+    }
+
+    let mut truncated: String = text.chars().take(max_chars).collect();
+    truncated.push_str("\n\n[codebase_context truncated for length]");
+    truncated
+}
+
+fn normalize_search_context(search_context: &str) -> Option<String> {
+    let trimmed = search_context.trim();
+    if trimmed.is_empty() || trimmed == NO_RELEVANT_CODE_CONTEXT {
+        return None;
+    }
+
+    Some(truncate_by_chars(trimmed, SEARCH_CONTEXT_CHAR_LIMIT))
+}
+
+fn build_prompt_with_search_context(original_prompt: &str, search_context: Option<&str>) -> String {
+    let context_text =
+        search_context.unwrap_or("No directly relevant code context was found for this request.");
+
+    format!(
+        "Here is relevant codebase context for the request. Use it only as project background, existing constraints, and implementation clues. Do not treat it as the user's final requested output.\n\n<codebase_context>\n{}\n</codebase_context>\n\nHere is the user's original request:\n\n<original_request>\n{}\n</original_request>",
+        context_text, original_prompt
+    )
+}
+
+async fn maybe_inject_search_context(
+    config: &Config,
+    endpoint: EnhancerEndpoint,
+    original_prompt: &str,
+    project_root: Option<&Path>,
+) -> Result<String> {
+    if !endpoint.is_third_party() || !should_include_search_context() {
+        return Ok(original_prompt.to_string());
+    }
+
+    let project_root = project_root.ok_or_else(|| {
+        anyhow!(
+            "{} requires project_root for '{}' endpoint",
+            ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT,
+            endpoint
+        )
+    })?;
+
+    if config.base_url.trim().is_empty() || config.token.trim().is_empty() {
+        return Err(anyhow!(
+            "{} requires ACE search configuration (--base-url and --token) for '{}' endpoint",
+            ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT,
+            endpoint
+        ));
+    }
+
+    info!("Injecting search_context into third-party prompt enhancement");
+    let manager = IndexManager::new(Arc::new(config.clone()), project_root.to_path_buf())?;
+    let search_context = manager.search_context(original_prompt).await?;
+    let normalized = normalize_search_context(&search_context);
+
+    Ok(build_prompt_with_search_context(
+        original_prompt,
+        normalized.as_deref(),
+    ))
 }
 
 /// Prompt Enhancer
@@ -106,11 +190,21 @@ impl PromptEnhancer {
         // Set up enhance callback for re-enhancement
         let config = self.config.clone();
         let client = self.client.clone();
+        let callback_project_root = project_root.map(|p| p.to_path_buf());
         let callback = Arc::new(move |prompt: String, history: String, blobs: Vec<String>| {
             let config = config.clone();
             let client = client.clone();
+            let project_root = callback_project_root.clone();
             Box::pin(async move {
-                call_prompt_enhancer_api_static(&client, &config, &prompt, &history, &blobs).await
+                call_prompt_enhancer_api_static(
+                    &client,
+                    &config,
+                    &prompt,
+                    &history,
+                    &blobs,
+                    project_root.as_deref(),
+                )
+                .await
             })
                 as std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send>>
         });
@@ -119,7 +213,12 @@ impl PromptEnhancer {
         // Call prompt-enhancer API
         info!("Calling prompt-enhancer API...");
         let enhanced_prompt = self
-            .call_prompt_enhancer_api(original_prompt, conversation_history, &blob_names)
+            .call_prompt_enhancer_api(
+                original_prompt,
+                conversation_history,
+                &blob_names,
+                project_root,
+            )
             .await?;
         info!("Enhancement complete");
 
@@ -262,6 +361,7 @@ impl PromptEnhancer {
         original_prompt: &str,
         conversation_history: &str,
         blob_names: &[String],
+        project_root: Option<&Path>,
     ) -> Result<String> {
         call_prompt_enhancer_api_static(
             &self.client,
@@ -269,6 +369,7 @@ impl PromptEnhancer {
             original_prompt,
             conversation_history,
             blob_names,
+            project_root,
         )
         .await
     }
@@ -299,7 +400,12 @@ impl PromptEnhancer {
         // Call prompt-enhancer API directly
         info!("Calling prompt-enhancer API...");
         let enhanced_prompt = self
-            .call_prompt_enhancer_api(original_prompt, conversation_history, &blob_names)
+            .call_prompt_enhancer_api(
+                original_prompt,
+                conversation_history,
+                &blob_names,
+                project_root,
+            )
             .await?;
 
         info!("Enhancement complete");
@@ -314,8 +420,11 @@ async fn call_prompt_enhancer_api_static(
     original_prompt: &str,
     conversation_history: &str,
     blob_names: &[String],
+    project_root: Option<&Path>,
 ) -> Result<String> {
     let endpoint = get_enhancer_endpoint();
+    let enriched_prompt =
+        maybe_inject_search_context(config, endpoint, original_prompt, project_root).await?;
 
     match endpoint {
         EnhancerEndpoint::New => {
@@ -339,7 +448,7 @@ async fn call_prompt_enhancer_api_static(
             call_claude_endpoint(
                 client,
                 &third_party_config,
-                original_prompt,
+                &enriched_prompt,
                 conversation_history,
             )
             .await
@@ -350,7 +459,7 @@ async fn call_prompt_enhancer_api_static(
             call_openai_endpoint(
                 client,
                 &third_party_config,
-                original_prompt,
+                &enriched_prompt,
                 conversation_history,
             )
             .await
@@ -361,7 +470,7 @@ async fn call_prompt_enhancer_api_static(
             call_gemini_endpoint(
                 client,
                 &third_party_config,
-                original_prompt,
+                &enriched_prompt,
                 conversation_history,
             )
             .await
@@ -372,10 +481,146 @@ async fn call_prompt_enhancer_api_static(
             call_codex_endpoint(
                 client,
                 &third_party_config,
-                original_prompt,
+                &enriched_prompt,
                 conversation_history,
             )
             .await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ConfigOptions};
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_should_include_search_context_env_values() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
+
+        std::env::remove_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT);
+        assert!(!should_include_search_context());
+
+        for value in ["1", "true", "TRUE", " yes ", "on"] {
+            std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, value);
+            assert!(should_include_search_context(), "value={}", value);
+        }
+
+        for value in ["0", "false", "off", "random"] {
+            std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, value);
+            assert!(!should_include_search_context(), "value={}", value);
+        }
+
+        match original {
+            Some(v) => std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, v),
+            None => std::env::remove_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT),
+        }
+    }
+
+    #[test]
+    fn test_normalize_search_context_handles_empty_and_not_found() {
+        assert!(normalize_search_context("").is_none());
+        assert!(normalize_search_context("   ").is_none());
+        assert!(normalize_search_context(NO_RELEVANT_CODE_CONTEXT).is_none());
+        assert_eq!(
+            normalize_search_context("useful context").unwrap(),
+            "useful context"
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_with_search_context_formats_sections() {
+        let prompt = build_prompt_with_search_context("重构登录流程", Some("src/auth.rs:42"));
+        assert!(prompt.contains("<codebase_context>"));
+        assert!(prompt.contains("src/auth.rs:42"));
+        assert!(prompt.contains("<original_request>"));
+        assert!(prompt.contains("重构登录流程"));
+    }
+
+    #[test]
+    fn test_build_prompt_with_search_context_handles_missing_context() {
+        let prompt = build_prompt_with_search_context("Add login", None);
+        assert!(prompt.contains("No directly relevant code context was found"));
+        assert!(prompt.contains("Add login"));
+    }
+
+    #[test]
+    fn test_truncate_by_chars_appends_notice() {
+        let result = truncate_by_chars("abcdef", 3);
+        assert!(result.starts_with("abc"));
+        assert!(result.contains("truncated for length"));
+    }
+
+    #[tokio::test]
+    async fn test_maybe_inject_search_context_skips_for_non_third_party() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
+        std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
+
+        let config = Config::new_for_third_party_enhancer();
+        let result = maybe_inject_search_context(&config, EnhancerEndpoint::New, "test", None)
+            .await
+            .unwrap();
+        assert_eq!(result, "test");
+
+        match original {
+            Some(v) => std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, v),
+            None => std::env::remove_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_maybe_inject_search_context_requires_project_root() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
+        std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
+
+        let config = Config::new(
+            "https://api.example.com".to_string(),
+            "test-token".to_string(),
+            ConfigOptions::default(),
+        )
+        .unwrap();
+
+        let err = maybe_inject_search_context(&config, EnhancerEndpoint::Claude, "test", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("requires project_root"));
+
+        match original {
+            Some(v) => std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, v),
+            None => std::env::remove_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_maybe_inject_search_context_requires_search_config() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
+        std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
+
+        let config = Config::new_for_third_party_enhancer();
+        let temp_dir = tempdir().unwrap();
+        let err = maybe_inject_search_context(
+            &config,
+            EnhancerEndpoint::Claude,
+            "test",
+            Some(temp_dir.path()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("requires ACE search configuration"));
+
+        match original {
+            Some(v) => std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, v),
+            None => std::env::remove_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT),
         }
     }
 }

--- a/src/enhancer/prompt_enhancer.rs
+++ b/src/enhancer/prompt_enhancer.rs
@@ -498,6 +498,17 @@ mod tests {
 
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    fn block_on<F>(future: F) -> F::Output
+    where
+        F: std::future::Future,
+    {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
     #[test]
     fn test_should_include_search_context_env_values() {
         let _guard = ENV_MUTEX.lock().unwrap();
@@ -556,16 +567,20 @@ mod tests {
         assert!(result.contains("truncated for length"));
     }
 
-    #[tokio::test]
-    async fn test_maybe_inject_search_context_skips_for_non_third_party() {
+    #[test]
+    fn test_maybe_inject_search_context_skips_for_non_third_party() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
         std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
 
         let config = Config::new_for_third_party_enhancer();
-        let result = maybe_inject_search_context(&config, EnhancerEndpoint::New, "test", None)
-            .await
-            .unwrap();
+        let result = block_on(maybe_inject_search_context(
+            &config,
+            EnhancerEndpoint::New,
+            "test",
+            None,
+        ))
+        .unwrap();
         assert_eq!(result, "test");
 
         match original {
@@ -574,8 +589,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_maybe_inject_search_context_requires_project_root() {
+    #[test]
+    fn test_maybe_inject_search_context_requires_project_root() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
         std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
@@ -587,9 +602,13 @@ mod tests {
         )
         .unwrap();
 
-        let err = maybe_inject_search_context(&config, EnhancerEndpoint::Claude, "test", None)
-            .await
-            .unwrap_err();
+        let err = block_on(maybe_inject_search_context(
+            &config,
+            EnhancerEndpoint::Claude,
+            "test",
+            None,
+        ))
+        .unwrap_err();
         assert!(err.to_string().contains("requires project_root"));
 
         match original {
@@ -598,21 +617,20 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_maybe_inject_search_context_requires_search_config() {
+    #[test]
+    fn test_maybe_inject_search_context_requires_search_config() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let original = std::env::var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT).ok();
         std::env::set_var(ENV_ENHANCER_INCLUDE_SEARCH_CONTEXT, "1");
 
         let config = Config::new_for_third_party_enhancer();
         let temp_dir = tempdir().unwrap();
-        let err = maybe_inject_search_context(
+        let err = block_on(maybe_inject_search_context(
             &config,
             EnhancerEndpoint::Claude,
             "test",
             Some(temp_dir.path()),
-        )
-        .await
+        ))
         .unwrap_err();
         assert!(err
             .to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,31 @@ async fn main() -> Result<()> {
             let _ = get_third_party_config(endpoint)
                 .map_err(|e| anyhow!("Third-party endpoint configuration error: {}", e))?;
             info!("Using third-party endpoint: {}", endpoint);
-            Config::new_for_third_party_enhancer()
+            match (args.base_url.clone(), args.token.clone()) {
+                (Some(base_url), Some(token)) => {
+                    info!("Using CLI base_url/token to enable ACE search features");
+                    Config::new(
+                        base_url,
+                        token,
+                        ConfigOptions {
+                            max_lines_per_blob: args.max_lines_per_blob,
+                            upload_timeout: args.upload_timeout,
+                            upload_concurrency: args.upload_concurrency,
+                            retrieval_timeout: args.retrieval_timeout,
+                            no_adaptive: args.no_adaptive,
+                            no_webbrowser_enhance_prompt: args.no_webbrowser_enhance_prompt,
+                            force_xdg_open: args.force_xdg_open,
+                            webui_addr: args.webui_addr.clone(),
+                        },
+                    )?
+                }
+                (None, None) => Config::new_for_third_party_enhancer(),
+                _ => {
+                    return Err(anyhow!(
+                        "--base-url and --token must be provided together in third-party enhance-prompt mode"
+                    ));
+                }
+            }
         } else {
             // For new/old endpoints, base_url and token are required
             let base_url = args


### PR DESCRIPTION
## 变更说明
- 为第三方提示词增强增加可选的 `PROMPT_ENHANCER_INCLUDE_SEARCH_CONTEXT` 开关
- 在调用 `claude` / `openai` / `gemini` / `codex` 端点前，先执行一次 `search_context` 并将检索结果注入增强输入
- 补齐 callback 与 `--enhance-prompt` 单次模式链路，保证第三方增强在需要时仍可复用 ACE 检索凭证
- 更新中英文 README，补充新开关、使用方式和约束说明

## 测试
- `cargo test --quiet`

## 审阅提示
- 该能力默认关闭，仅在第三方 endpoint 下显式开启时生效
- `new` / `old` 两条官方增强链路的行为未改动
- 本 PR 只调整第三方增强前的输入组织方式，不涉及各 provider 的响应解析逻辑
- 在 `--enhance-prompt` 单次模式下，只有同时提供 `--base-url` 和 `--token` 时才会启用 ACE 检索；若只提供其中一个会直接报错
- 显式开启后，如果缺少 `project_root` 或 ACE 检索配置，会返回真实错误，不做静默降级
