### PR TITLE
feat: add custom index.bin filename option for multi-instance isolation

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -86,6 +86,7 @@ ace-tool-rs --base-url <API_URL> --token <AUTH_TOKEN>
 | `--enhance-prompt` | 增强提示词并输出到标准输出，然后退出 |
 | `--max-lines-per-blob` | 每个 blob 块的最大行数（默认：800） |
 | `--retrieval-timeout` | 搜索检索超时时间（秒，默认：180） |
+| `--index-bin` | 自定义索引文件名，默认为 `index.bin`（例如使用 `index-1.bin` 隔离不同的实例） |
 
 ### 环境变量
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ ace-tool-rs --base-url <API_URL> --token <AUTH_TOKEN>
 | `--enhance-prompt` | Enhance a prompt and output the result to stdout, then exit |
 | `--max-lines-per-blob` | Maximum lines per blob chunk (default: 800) |
 | `--retrieval-timeout` | Search retrieval timeout in seconds (default: 180) |
+| `--index-bin` | Customize the index filename, default is `index.bin` (e.g. `index-1.bin` to isolate multiple instances) |
 
 ### Environment Variables
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct ConfigOptions {
     pub force_xdg_open: bool,
     /// Custom bind address for the web UI server (e.g., "127.0.0.1:8754", "0.0.0.0:3456")
     pub webui_addr: Option<String>,
+    pub index_bin: Option<String>,
 }
 
 /// Main configuration struct
@@ -39,6 +40,7 @@ pub struct Config {
     pub force_xdg_open: bool,
     /// Custom bind address for the web UI server
     pub webui_addr: Option<String>,
+    pub index_bin: String,
     pub cli_overrides: CliOverrides,
     pub text_extensions: HashSet<String>,
     pub text_filenames: HashSet<String>,
@@ -86,6 +88,7 @@ impl Config {
             no_webbrowser_enhance_prompt: options.no_webbrowser_enhance_prompt,
             force_xdg_open: options.force_xdg_open,
             webui_addr: options.webui_addr,
+            index_bin: options.index_bin.unwrap_or_else(|| "index.bin".to_string()),
             cli_overrides: CliOverrides {
                 upload_timeout_secs: options.upload_timeout,
                 upload_concurrency: options.upload_concurrency,
@@ -108,6 +111,7 @@ impl Config {
             no_webbrowser_enhance_prompt: true,
             force_xdg_open: false,
             webui_addr: None,
+            index_bin: "index.bin".to_string(),
             cli_overrides: CliOverrides::default(),
             text_extensions: default_text_extensions(),
             text_filenames: default_text_filenames(),

--- a/src/enhancer/prompt_enhancer.rs
+++ b/src/enhancer/prompt_enhancer.rs
@@ -334,7 +334,7 @@ impl PromptEnhancer {
 
     /// Load blob names from index file
     fn load_blob_names(&self, project_root: &Path) -> Vec<String> {
-        let index_file_path = get_index_file_path(project_root);
+        let index_file_path = get_index_file_path(project_root, &self.config.index_bin);
 
         if !index_file_path.exists() {
             return Vec::new();

--- a/src/index/manager.rs
+++ b/src/index/manager.rs
@@ -211,7 +211,7 @@ impl IndexManager {
         let normalized = normalize_path(&project_root, runtime_env);
         let project_root = normalized.local;
 
-        let index_file_path = get_index_file_path(&project_root);
+        let index_file_path = get_index_file_path(&project_root, &config.index_bin);
 
         // Precompile exclude patterns to regex
         let compiled_patterns: Vec<(String, Option<Regex>)> = config

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,10 @@ struct Args {
     /// Enhance a prompt and output the result to stdout, then exit
     #[arg(long)]
     enhance_prompt: Option<String>,
+
+    /// Customize the index.bin filename (default: "index.bin")
+    #[arg(long, default_value = "index.bin")]
+    index_bin: String,
 }
 
 #[tokio::main]
@@ -119,6 +123,7 @@ async fn main() -> Result<()> {
                             no_webbrowser_enhance_prompt: args.no_webbrowser_enhance_prompt,
                             force_xdg_open: args.force_xdg_open,
                             webui_addr: args.webui_addr.clone(),
+                            index_bin: Some(args.index_bin.clone()),
                         },
                     )?
                 }
@@ -151,6 +156,7 @@ async fn main() -> Result<()> {
                     no_webbrowser_enhance_prompt: args.no_webbrowser_enhance_prompt,
                     force_xdg_open: args.force_xdg_open,
                     webui_addr: args.webui_addr.clone(),
+                    index_bin: Some(args.index_bin.clone()),
                 },
             )?
         };
@@ -184,6 +190,7 @@ async fn main() -> Result<()> {
             no_webbrowser_enhance_prompt: args.no_webbrowser_enhance_prompt,
             force_xdg_open: args.force_xdg_open,
             webui_addr: args.webui_addr,
+            index_bin: Some(args.index_bin),
         },
     )?;
 

--- a/src/utils/project_detector.rs
+++ b/src/utils/project_detector.rs
@@ -62,7 +62,7 @@ fn gitignore_has_ace_tool(content: &str) -> bool {
 }
 
 /// Get index file path
-pub fn get_index_file_path(project_root: &Path) -> PathBuf {
+pub fn get_index_file_path(project_root: &Path, index_bin: &str) -> PathBuf {
     let ace_dir = get_ace_dir(project_root);
-    ace_dir.join("index.bin")
+    ace_dir.join(index_bin)
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -77,11 +77,13 @@ fn test_config_with_custom_values() {
             no_webbrowser_enhance_prompt: true,
             force_xdg_open: false,
             webui_addr: None,
+            index_bin: Some("custom-index.bin".to_string()),
         },
     )
     .unwrap();
     assert_eq!(config.max_lines_per_blob, 500);
     assert_eq!(config.retrieval_timeout_secs, 120);
+    assert_eq!(config.index_bin, "custom-index.bin");
     assert!(config.no_adaptive);
     assert!(config.no_webbrowser_enhance_prompt);
     assert_eq!(config.cli_overrides.upload_timeout_secs, Some(60));

--- a/tests/index_test.rs
+++ b/tests/index_test.rs
@@ -932,3 +932,83 @@ fn test_index_result_error() {
     assert_eq!(result.status, "error");
     assert!(result.stats.is_none());
 }
+
+#[test]
+fn test_multi_instance_isolation() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().to_path_buf();
+
+    // Create two config instances with different index_bin values
+    let config1 = Config::new(
+        "https://api.example.com".to_string(),
+        "test-token".to_string(),
+        ConfigOptions {
+            index_bin: Some("index-1.bin".to_string()),
+            ..ConfigOptions::default()
+        },
+    )
+    .unwrap();
+
+    let config2 = Config::new(
+        "https://api.example.com".to_string(),
+        "test-token".to_string(),
+        ConfigOptions {
+            index_bin: Some("index-2.bin".to_string()),
+            ..ConfigOptions::default()
+        },
+    )
+    .unwrap();
+
+    // Create two managers
+    let manager1 = IndexManager::new(config1, project_root.clone()).unwrap();
+    let manager2 = IndexManager::new(config2, project_root.clone()).unwrap();
+
+    // Save different data in manager1
+    let mut index1 = IndexData {
+        version: 2,
+        config_hash: manager1.config_hash().to_string(),
+        entries: HashMap::new(),
+    };
+    index1.entries.insert(
+        "file1.rs".to_string(),
+        FileEntry {
+            mtime_secs: 1000,
+            mtime_nanos: 0,
+            size: 100,
+            blob_hashes: vec!["hash1".to_string()],
+        },
+    );
+    manager1.save_index(&index1).unwrap();
+
+    // Save different data in manager2
+    let mut index2 = IndexData {
+        version: 2,
+        config_hash: manager2.config_hash().to_string(),
+        entries: HashMap::new(),
+    };
+    index2.entries.insert(
+        "file2.rs".to_string(),
+        FileEntry {
+            mtime_secs: 2000,
+            mtime_nanos: 0,
+            size: 200,
+            blob_hashes: vec!["hash2".to_string()],
+        },
+    );
+    manager2.save_index(&index2).unwrap();
+
+    // Verify both files exist independently
+    let file1_path = project_root.join(".ace-tool").join("index-1.bin");
+    let file2_path = project_root.join(".ace-tool").join("index-2.bin");
+    assert!(file1_path.exists());
+    assert!(file2_path.exists());
+
+    // Load and verify data isolation
+    let loaded1 = manager1.load_index();
+    assert_eq!(loaded1.entries.len(), 1);
+    assert!(loaded1.entries.contains_key("file1.rs"));
+
+    let loaded2 = manager2.load_index();
+    assert_eq!(loaded2.entries.len(), 1);
+    assert!(loaded2.entries.contains_key("file2.rs"));
+}

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -119,7 +119,7 @@ fn test_get_ace_dir_handles_gitignore_without_trailing_newline() {
 #[test]
 fn test_get_index_file_path() {
     let temp_dir = TempDir::new().unwrap();
-    let index_path = get_index_file_path(temp_dir.path());
+    let index_path = get_index_file_path(temp_dir.path(), "index.bin");
 
     assert_eq!(
         index_path,
@@ -133,8 +133,8 @@ fn test_get_index_file_path() {
 fn test_get_index_file_path_consistent() {
     let temp_dir = TempDir::new().unwrap();
 
-    let path1 = get_index_file_path(temp_dir.path());
-    let path2 = get_index_file_path(temp_dir.path());
+    let path1 = get_index_file_path(temp_dir.path(), "index.bin");
+    let path2 = get_index_file_path(temp_dir.path(), "index.bin");
 
     assert_eq!(path1, path2);
 }


### PR DESCRIPTION
- Add --index-bin CLI option to customize index filename (default: "index.bin")
- Enable multiple ace-tool instances to run simultaneously with isolated indexes
- Update README documentation with new flag description
- Modify internal API to accept custom index filename parameter
- Add comprehensive tests for multi-instance isolation functionality